### PR TITLE
Bump version to 0.9.5561

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM clojure:lein-2.6.1-alpine
 
 MAINTAINER Christian Romney "cromney@pointslope.com"
 
-ENV DATOMIC_VERSION 0.9.5544
+ENV DATOMIC_VERSION 0.9.5561
 ENV DATOMIC_HOME /opt/datomic-pro-$DATOMIC_VERSION
 ENV DATOMIC_DATA $DATOMIC_HOME/data
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ No other configuration is necessary. Simply **docker build** and
 
 ## Example Dockerfile
 
-    FROM pointslope/datomic-pro-starter:0.9.5544
+    FROM pointslope/datomic-pro-starter:0.9.5561
     MAINTAINER John Doe "jdoe@example.org"
     CMD ["config/dev-transactor.properties"]
 


### PR DESCRIPTION
Nice `bump.sh` script 👍 

Could make it even better by scraping https://my.datomic.com/downloads/free for the latest version and bumping, committing, pushing in a Travis build or similar 😄 .